### PR TITLE
Make Popper hover-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,19 @@ yarn add vue3-popper
 
 ## Props
 
-| Name               | Default  | Description                                                                 |
-| ------------------ | -------- | --------------------------------------------------------------------------- |
-| `placement`        | `bottom` | Preferred placement of the Popper                                           |
-| `disableClickAway` | `false`  | Disables automatically closing the Popper when the user clicks away from it |
-| `offsetX`          | `0`      | Distance in pixels along the trigger element                                |
-| `offsetY`          | `12`     | Distance in pixels away from the trigger element                            |
-| `hover`            | `false`  | Trigger the Popper on hover                                                 |
-| `arrow`            | `false`  | Display an arrow on the Popper                                              |
-| `arrowPadding`     | `0`      | Stop arrow from reaching the edge of the Popper (in pixels)                 |
-| `disabled`         | `false`  | Disables the Popper. If it was already open, it will be closed.             |
-| `openDelay`        | `0`      | Open the Popper after a delay (ms)                                          |
-| `closeDelay`       | `0`      | Close the Popper after a delay (ms)                                         |
+| Name               | Default  | Description                                                                        |
+| ------------------ | -------- | ---------------------------------------------------------------------------------- |
+| `placement`        | `bottom` | Preferred placement of the Popper                                                  |
+| `disableClickAway` | `false`  | Disables automatically closing the Popper when the user clicks away from it        |
+| `offsetSkid`       | `0`      | Offset in pixels along the trigger element                                         |
+| `offsetDistance`   | `12`     | Offset in pixels away from the trigger element                                     |
+| `hover`            | `false`  | Trigger the Popper on hover                                                        |
+| `arrow`            | `false`  | Display an arrow on the Popper                                                     |
+| `arrowPadding`     | `0`      | Stop arrow from reaching the edge of the Popper (in pixels)                        |
+| `disabled`         | `false`  | Disables the Popper. If it was already open, it will be closed.                    |
+| `openDelay`        | `0`      | Open the Popper after a delay (ms)                                                 |
+| `closeDelay`       | `0`      | Close the Popper after a delay (ms)                                                |
+| `interactive`      | `true`   | If the Popper should be interactive, it will close when clicked/hovered when false |
 
 ## Events
 
@@ -85,9 +86,10 @@ yarn add vue3-popper
 
 The `content` slot gives you access to useful variables and functions.
 
-| Name    | Type     | Description                    |
-| ------- | -------- | ------------------------------ |
-| `close` | function | A function to close the Popper |
+| Name     | Type     | Description                    |
+| -------- | -------- | ------------------------------ |
+| `close`  | function | A function to close the Popper |
+| `isOpen` | boolean  | The `open` state of the Popper |
 
 ## CSS variables
 

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -2,18 +2,19 @@
 
 ## Props
 
-| Name               | Default  | Description                                                                 |
-| ------------------ | -------- | --------------------------------------------------------------------------- |
-| `placement`        | `bottom` | Preferred placement of the Popper                                           |
-| `disableClickAway` | `false`  | Disables automatically closing the Popper when the user clicks away from it |
-| `offsetX`          | `0`      | Distance in pixels along the trigger element                                |
-| `offsetY`          | `12`     | Distance in pixels away from the trigger element                            |
-| `hover`            | `false`  | Trigger the Popper on hover                                                 |
-| `arrow`            | `false`  | Display an arrow on the Popper                                              |
-| `arrowPadding`     | `0`      | Stop arrow from reaching the edge of the Popper (in pixels)                 |
-| `disabled`         | `false`  | Disables the Popper. If it was already open, it will be closed.             |
-| `openDelay`        | `0`      | Open the Popper after a delay (ms)                                          |
-| `closeDelay`       | `0`      | Close the Popper after a delay (ms)                                         |
+| Name               | Default  | Description                                                                        |
+| ------------------ | -------- | ---------------------------------------------------------------------------------- |
+| `placement`        | `bottom` | Preferred placement of the Popper                                                  |
+| `disableClickAway` | `false`  | Disables automatically closing the Popper when the user clicks away from it        |
+| `offsetSkid`       | `0`      | Offset in pixels along the trigger element                                         |
+| `offsetDistance`   | `12`     | Offset in pixels away from the trigger element                                     |
+| `hover`            | `false`  | Trigger the Popper on hover                                                        |
+| `arrow`            | `false`  | Display an arrow on the Popper                                                     |
+| `arrowPadding`     | `0`      | Stop arrow from reaching the edge of the Popper (in pixels)                        |
+| `disabled`         | `false`  | Disables the Popper. If it was already open, it will be closed.                    |
+| `openDelay`        | `0`      | Open the Popper after a delay (ms)                                                 |
+| `closeDelay`       | `0`      | Close the Popper after a delay (ms)                                                |
+| `interactive`      | `true`   | If the Popper should be interactive, it will close when clicked/hovered when false |
 
 ## Events
 
@@ -32,9 +33,10 @@
 
 The `content` slot gives you access to useful variables and functions.
 
-| Name    | Type     | Description                    |
-| ------- | -------- | ------------------------------ |
-| `close` | function | A function to close the Popper |
+| Name     | Type     | Description                    |
+| -------- | -------- | ------------------------------ |
+| `close`  | function | A function to close the Popper |
+| `isOpen` | boolean  | The `open` state of the Popper |
 
 ## CSS variables
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue3-popper",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue3-popper",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue3-popper",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Valgeir Björnsson",
     "email": "valgeir@hey.com",

--- a/src/component/Popper.vue
+++ b/src/component/Popper.vue
@@ -1,9 +1,12 @@
 <template>
-  <div v-click-away="{ handler: handleClose, enabled: enableClickAway }">
+  <div
+    :style="interactiveStyle"
+    @mouseleave="hover && handleClose()"
+    v-click-away="{ handler: handleClose, enabled: enableClickAway }"
+  >
     <div
       ref="triggerNode"
       @mouseover="hover && handleOpen()"
-      @mouseleave="hover && handleClose()"
       @click="handleToggle"
       @focus="handleOpen"
       @blur="handleClose"
@@ -15,6 +18,7 @@
     </div>
     <Transition name="fade">
       <div
+        @click="!interactive && handleToggle()"
         v-show="shouldShowPopper"
         :class="['popper', shouldShowPopper ? 'inline-block' : null]"
         ref="popperNode"
@@ -80,16 +84,16 @@
         default: false,
       },
       /**
-       * Distance in pixels along the trigger element
+       * Offset in pixels along the trigger element
        */
-      offsetX: {
+      offsetSkid: {
         type: String,
         default: "0",
       },
       /**
-       * Distance in pixels away from the trigger element
+       * Offset in pixels away from the trigger element
        */
-      offsetY: {
+      offsetDistance: {
         type: String,
         default: "12",
       },
@@ -135,6 +139,10 @@
         type: String,
         default: "0",
       },
+      interactive: {
+        type: Boolean,
+        default: true,
+      },
     },
     setup(props, { slots, emit }) {
       const children = slots.default();
@@ -150,21 +158,22 @@
       const modifiedIsOpen = ref(false);
 
       const {
-        offsetX,
-        offsetY,
+        offsetSkid,
+        offsetDistance,
         arrowPadding,
         placement,
         disabled,
         disableClickAway,
         openDelay,
         closeDelay,
+        interactive,
       } = toRefs(props);
 
       const { isOpen, open, close } = usePopper({
         popperNode,
         triggerNode,
-        offsetX,
-        offsetY,
+        offsetSkid,
+        offsetDistance,
         arrowPadding,
         placement,
         emit,
@@ -218,6 +227,12 @@
       const invalid = computed(() => disabled.value || !hasContent.value);
       const shouldShowPopper = computed(() => isOpen.value && !invalid.value);
       const enableClickAway = computed(() => !disableClickAway.value);
+      // Add an invisible border to keep the Popper open when hovering from the trigger into it
+      const interactiveStyle = computed(() =>
+        interactive.value
+          ? `border: ${offsetDistance.value}px solid transparent; margin: -${offsetDistance.value}px;`
+          : null,
+      );
 
       return {
         popperNode,
@@ -230,6 +245,8 @@
         shouldShowPopper,
         enableClickAway,
         modifiedIsOpen,
+        interactive,
+        interactiveStyle,
       };
     },
   });

--- a/src/composables/usePopper.js
+++ b/src/composables/usePopper.js
@@ -12,8 +12,8 @@ export default function usePopper({
   triggerNode,
   placement,
   arrowPadding,
-  offsetX,
-  offsetY,
+  offsetSkid,
+  offsetDistance,
   emit,
 }) {
   const state = reactive({
@@ -64,7 +64,7 @@ export default function usePopper({
         {
           name: "offset",
           options: {
-            offset: [toInt(offsetX.value), toInt(offsetY.value)],
+            offset: [toInt(offsetSkid.value), toInt(offsetDistance.value)],
           },
         },
       ],


### PR DESCRIPTION
- Add `interactive` prop
- Make Popper hoverable by default
- Rename offset props for more clarity

Closes #11 